### PR TITLE
Added Assertions

### DIFF
--- a/src/main/java/Timo.java
+++ b/src/main/java/Timo.java
@@ -159,7 +159,7 @@ class Storage {
                         arr.add(new Deadline(false, b[0], datetime));
                     }
                 } else {
-                    //removing the [E][?] from the line
+                    assert tmp.startsWith("[E]") : "Error in program";
                     String details = tmp.split("] ", 2)[1];
                     //getting important values to create the Event
                     String[] split_up = details.split(" \\(from: | to: |\\)");
@@ -168,6 +168,7 @@ class Storage {
                     if (Character.compare(tmp.charAt(4), 'X') == 0) {
                         arr.add(new Event(true, split_up[0], split_up[1], split_up[2]));
                     } else {
+                        assert Character.compare(tmp.charAt(4), ' ') == 0 : "Error in file";
                         arr.add(new Event(false, split_up[0], split_up[1], split_up[2]));
                     }
                 }
@@ -469,8 +470,10 @@ class Parser {
         case "mark":
             String taskNumber = String.valueOf(command.charAt(command.length() - 1));
 
+
             //get the Task number to mark
             int markTarget = Integer.parseInt(taskNumber);
+
 
             //find the task to mark
             Task markedTask = this.taskList.mark(markTarget);


### PR DESCRIPTION
statement assumes that the task is an event and does not check whether it is in fact an event.

Similarly, when loading the lines from the text, I only check that it is marked, and the other case assumed that the task is unmarked

I did not account for the case where task might not be unmarked, but rather other characters are placed inside, or it might not be an event, but rather some other characters, which can happen if users tamper with the list text file manually

Two assert have been added, to check if it is a task is an event, and to check if the task is unmarked, instead of assuming